### PR TITLE
Add Nedis Smart Plug WIFIP110FWT and related profile

### DIFF
--- a/devices/nedis-wifip110nwt-smart-plug.json
+++ b/devices/nedis-wifip110nwt-smart-plug.json
@@ -1,0 +1,250 @@
+{
+	"manufacturer": "Nedis",
+	"name": "WIFIP110FWT Smart Plug",
+	"key": "keya5yka7xy4ttmp",
+	"ap_ssid": "SmartLife",
+	"github_issues": [],
+	"image_urls": [],
+	"profiles": [
+		"oem-bk7231n-dltj-plug-05-liou-1.0.0-sdk-2.3.3-40.00"
+	],
+	"schemas": {
+		"000004h2kg": [
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"type": "bool"
+				},
+				"id": 1
+			},
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"min": 0,
+					"max": 86400,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 9
+			},
+			{
+				"mode": "ro",
+				"property": {
+					"min": 0,
+					"max": 50000,
+					"scale": 3,
+					"step": 100,
+					"type": "value"
+				},
+				"id": 17,
+				"type": "obj"
+			},
+			{
+				"mode": "ro",
+				"property": {
+					"min": 0,
+					"max": 30000,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 18,
+				"type": "obj"
+			},
+			{
+				"mode": "ro",
+				"property": {
+					"min": 0,
+					"max": 80000,
+					"scale": 1,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 19,
+				"type": "obj"
+			},
+			{
+				"mode": "ro",
+				"property": {
+					"min": 0,
+					"max": 5000,
+					"scale": 1,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 20,
+				"type": "obj"
+			},
+			{
+				"mode": "ro",
+				"property": {
+					"min": 0,
+					"max": 5,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 21,
+				"type": "obj"
+			},
+			{
+				"mode": "ro",
+				"property": {
+					"min": 0,
+					"max": 1000000,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 22,
+				"type": "obj"
+			},
+			{
+				"mode": "ro",
+				"property": {
+					"min": 0,
+					"max": 1000000,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 23,
+				"type": "obj"
+			},
+			{
+				"mode": "ro",
+				"property": {
+					"min": 0,
+					"max": 1000000,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 24,
+				"type": "obj"
+			},
+			{
+				"mode": "ro",
+				"property": {
+					"min": 0,
+					"max": 1000000,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 25,
+				"type": "obj"
+			},
+			{
+				"mode": "ro",
+				"property": {
+					"type": "bitmap",
+					"maxlen": 6
+				},
+				"id": 26,
+				"type": "obj"
+			},
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"range": [
+						"off",
+						"on",
+						"memory"
+					],
+					"type": "enum"
+				},
+				"id": 38
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"type": "bool"
+				},
+				"id": 39,
+				"type": "obj"
+			},
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"range": [
+						"relay",
+						"pos",
+						"none",
+						"on"
+					],
+					"type": "enum"
+				},
+				"id": 40
+			},
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"type": "bool"
+				},
+				"id": 41
+			},
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 42
+			},
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 43
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 44,
+				"type": "obj"
+			}
+		]
+	},
+	"device_configuration": {
+		"bt1_lv": 0,
+		"bt1_pin": 9,
+		"bt1_type": 0,
+		"ch1_stat": 2,
+		"ch_cddpid1": 9,
+		"ch_dpid1": 1,
+		"ch_num": 1,
+		"chip_type": 3,
+		"crc": 70,
+		"ele_fun_en": 1,
+		"ffc_select": 0,
+		"jv": "1.0.0",
+		"lose_vol": 85,
+		"min_power_report": 1,
+		"module": "CBU",
+		"net_trig": 1,
+		"netled1_lv": 0,
+		"netled1_pin": 6,
+		"netled_reuse": 1,
+		"over_cur": 10000,
+		"over_vol": 260,
+		"reset_t": 5,
+		"rl1_lv": 1,
+		"rl1_pin": 26,
+		"rl1_type": 0,
+		"vol_def": 0
+	}
+}

--- a/profiles/oem-bk7231n-dltj-plug-05-liou-1.0.0-sdk-2.3.3-40.00.json
+++ b/profiles/oem-bk7231n-dltj-plug-05-liou-1.0.0-sdk-2.3.3-40.00.json
@@ -1,0 +1,17 @@
+{
+	"name": "1.0.0 - BK7231N",
+	"sub_name": "oem_bk7231n_dltj_plug_05_liou",
+	"type": "CLASSIC",
+	"icon": "power-plug",
+	"firmware": {
+		"chip": "BK7231N",
+		"name": "oem_bk7231n_dltj_plug_05_liou",
+		"version": "1.0.0",
+		"sdk": "2.3.3-40.00",
+		"key": "keya5yka7xy4ttmp"
+	},
+	"data": {
+		"address_finish": "0x1B2D3",
+		"address_ssid": "0xC8093"
+	}
+}


### PR DESCRIPTION
Related to https://github.com/tuya-cloudcutter/lightleak/issues/7. 
Successfully flashed OpenBK7231N_UG_1.15.280.bin with tuya-cloudcutter with this profile.