### PR TITLE
Add Treatlife DP10 Smart Plug-in Dimmer Profile

### DIFF
--- a/devices/treatlife-dp10-smart-dimmer-plug.json
+++ b/devices/treatlife-dp10-smart-dimmer-plug.json
@@ -1,0 +1,106 @@
+{
+	"manufacturer": "Treatlife",
+	"name": "DP10 smart dimmer plug",
+	"key": "vgeiuan7sdjfkcuu",
+	"ap_ssid": "TreatLife-SL",
+	"github_issues": [],
+	"image_urls": [],
+	"profiles": [
+		"bk7231n-common-user-config-ty-2.0.2-sdk-2.3.1-40.00"
+	],
+	"schemas": {
+		"000004cn7x": [
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"type": "bool"
+				},
+				"id": 1
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"min": 10,
+					"max": 1000,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 2,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"min": 10,
+					"max": 1000,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 3,
+				"type": "obj"
+			},
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"range": [
+						"LED",
+						"incandescent",
+						"halogen"
+					],
+					"type": "enum"
+				},
+				"id": 4
+			},
+			{
+				"mode": "rw",
+				"id": 101,
+				"type": "raw"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"min": 0,
+					"max": 1440,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 102,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"min": 10,
+					"max": 1000,
+					"scale": 1,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 103,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"min": 0,
+					"max": 2,
+					"scale": 1,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 104,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"id": 105,
+				"type": "raw"
+			}
+		]
+	}
+}


### PR DESCRIPTION
Adds Treatlife DP10 (BK7231N) support. 

Forum post for teardown: https://www.elektroda.com/rtvforum/viewtopic.php?p=20950756

According to [another forum post](https://www.elektroda.com/rtvforum/topic3993247.html), it looks like there is another variation of the DP10 out there using a BK7231T, but mine had a BK7231N.  The autoexec.bat example worked flawlessly for mine.

I'm a little new to all of the Tuya configurations and OpenBeken, particularly the TuyaMCU part. Is there a way to make the autoexec.bat part of the device profiles? Or, is that only supported for the pin layouts that don't appear to exist for TuyaMCU devices?