### PR TITLE
Add v1.0.6 for Feit FETAPE/RGBW/CNTRSC

### DIFF
--- a/devices/feit-fetape-rgbw-cntrsc-led-strip-v1.0.6.json
+++ b/devices/feit-fetape-rgbw-cntrsc-led-strip-v1.0.6.json
@@ -1,10 +1,12 @@
 {
-	"manufacturer": "Feit Electric",
-	"name": "FETAPE/RGBW/CNTRSC FW1.0.6",
+	"manufacturer": "Feit",
+	"name": "FETAPE-RGBW-CNTRSC LED Strip v1.0.6",
 	"key": "s4z3nskgoy958zut",
 	"ap_ssid": "SmartLife",
 	"github_issues": [],
-	"image_urls": "feit-tape16-rgbw-rp-led-strip.jpg",
+	"image_urls": [
+		"feit-tape16-rgbw-rp-led-strip.jpg"
+	],
 	"profiles": [
 		"potek-lst-fw-1.0.6-sdk-2.3.1-40.00"
 	],

--- a/devices/feit-fetape-rgbw-cntrsc-led-strip-v1.0.6.json
+++ b/devices/feit-fetape-rgbw-cntrsc-led-strip-v1.0.6.json
@@ -1,0 +1,130 @@
+{
+	"manufacturer": "Feit Electric",
+	"name": "FETAPE/RGBW/CNTRSC FW1.0.6",
+	"key": "s4z3nskgoy958zut",
+	"ap_ssid": "SmartLife",
+	"github_issues": [],
+	"image_urls": [],
+	"profiles": [
+		"potek-lst-fw-1.0.6-sdk-2.3.1-40.00"
+	],
+	"schemas": {
+		"000003kuc7": [
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"type": "bool"
+				},
+				"id": 20
+			},
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"range": [
+						"white",
+						"colour",
+						"scene",
+						"music"
+					],
+					"type": "enum"
+				},
+				"id": 21
+			},
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"min": 1,
+					"max": 1000,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 22
+			},
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 24
+			},
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 25
+			},
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"min": 0,
+					"max": 86400,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 26
+			},
+			{
+				"type": "obj",
+				"mode": "wr",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 27
+			},
+			{
+				"type": "obj",
+				"mode": "wr",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 28
+			}
+		]
+	},
+	"device_configuration": {
+		"Jsonver": "1.1.0",
+		"b_lv": 1,
+		"b_pin": 7,
+		"brightmax": 100,
+		"brightmin": 10,
+		"c_lv": 1,
+		"c_pin": 6,
+		"cmod": "rgbc",
+		"colormax": 100,
+		"colormin": 10,
+		"cwmaxp": 100,
+		"cwtype": 0,
+		"defbright": 100,
+		"defcolor": "c",
+		"deftemp": 100,
+		"dmod": 0,
+		"g_lv": 1,
+		"g_pin": 8,
+		"module": "CBU",
+		"onoffmode": 0,
+		"pmemory": 1,
+		"pwmhz": 16000,
+		"r_lv": 1,
+		"r_pin": 9,
+		"rstbr": 50,
+		"rstcor": "c",
+		"rstmode": 0,
+		"rstnum": 3,
+		"rsttemp": 100,
+		"title20": 0,
+		"wfcfg": "spcl_auto"
+	}
+}

--- a/devices/feit-fetape-rgbw-cntrsc-led-strip-v1.0.6.json
+++ b/devices/feit-fetape-rgbw-cntrsc-led-strip-v1.0.6.json
@@ -4,7 +4,7 @@
 	"key": "s4z3nskgoy958zut",
 	"ap_ssid": "SmartLife",
 	"github_issues": [],
-	"image_urls": [],
+	"image_urls": "feit-tape16-rgbw-rp-led-strip.jpg",
 	"profiles": [
 		"potek-lst-fw-1.0.6-sdk-2.3.1-40.00"
 	],

--- a/profiles/potek-lst-fw-1.0.6-sdk-2.3.1-40.00.json
+++ b/profiles/potek-lst-fw-1.0.6-sdk-2.3.1-40.00.json
@@ -1,0 +1,17 @@
+{
+	"name": "1.0.6 - BK7231N",
+	"sub_name": "POTEK_LST_FW",
+	"type": "CLASSIC",
+	"icon": "memory",
+	"firmware": {
+		"chip": "BK7231N",
+		"name": "POTEK_LST_FW",
+		"version": "1.0.6",
+		"sdk": "2.3.1-40.00"
+	},
+	"data": {
+		"address_finish": "0x1B39B",
+		"address_ssid": "0xC83B5",
+		"address_ssid_padding": 4
+	}
+}


### PR DESCRIPTION
Existing profiles for this device or other BK7231N FW v1.0.6 profiles would not work, have successfully tested this new profile as working. Hardware looks identical to the v1.0.9 profile for same device, and same config works