### PR TITLE
Add TreatLife DP10 variant using v2.1.6 profile.

### DIFF
--- a/devices/treatlife-dp10-smart-dimmer-plug-bk7231n-v2.1.6.json
+++ b/devices/treatlife-dp10-smart-dimmer-plug-bk7231n-v2.1.6.json
@@ -1,0 +1,108 @@
+{
+	"manufacturer": "Treatlife",
+	"name": "DP10 smart dimmer plug BK7231N v2.1.6",
+	"key": "vgeiuan7sdjfkcuu",
+	"ap_ssid": "TreatLife-SL",
+	"github_issues": [],
+	"image_urls": [
+		"treatlife-dp10-smart-dimmer-plug-bk7231n-v2.0.2.jpg"
+	],
+	"profiles": [
+		"bk7231n-common-user-config-ty-2.1.6-sdk-2.3.3-40.00"
+	],
+	"schemas": {
+		"000004cn7x": [
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"type": "bool"
+				},
+				"id": 1
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"min": 10,
+					"max": 1000,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 2,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"min": 10,
+					"max": 1000,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 3,
+				"type": "obj"
+			},
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"range": [
+						"LED",
+						"incandescent",
+						"halogen"
+					],
+					"type": "enum"
+				},
+				"id": 4
+			},
+			{
+				"mode": "rw",
+				"id": 101,
+				"type": "raw"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"min": 0,
+					"max": 1440,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 102,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"min": 10,
+					"max": 1000,
+					"scale": 1,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 103,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"min": 0,
+					"max": 2,
+					"scale": 1,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 104,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"id": 105,
+				"type": "raw"
+			}
+		]
+	}
+}


### PR DESCRIPTION
My recently purchased (June 2024) TreatLife DP10 Smart Outdoor Dimmer would not get successfully exploited with the v2.0.2 profile in tuya-cloudcutter. After some investigation, I found that modifying the existing device JSON file to use v2.1.6 profile works perfectly.

For reference, the unit I have has a CB3S module and the PCB is labeled:

```
DP10_JL_v7.3
2023-4-23
```