### PR TITLE
New device - Linovum RGBW LED module

### DIFF
--- a/devices/linovum-ean4260457686189-rgbw-led-module
+++ b/devices/linovum-ean4260457686189-rgbw-led-module
@@ -1,0 +1,147 @@
+{
+	"manufacturer": "Linovum",
+	"name": "EAN4260457686189 RGBW LED Module",
+	"key": "key8u54q9dtru5jw",
+	"ap_ssid": "SmartLife",
+	"github_issues": [],
+	"image_urls": [],
+	"profiles": [
+		"oem-bk7231n-light-ty-1.3.20-sdk-2.3.3-40.00"
+	],
+	"schemas": {
+		"0000046voh": [
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"type": "bool"
+				},
+				"id": 20
+			},
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"range": [
+						"white",
+						"colour",
+						"scene",
+						"music"
+					],
+					"type": "enum"
+				},
+				"id": 21
+			},
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"min": 10,
+					"max": 1000,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 22
+			},
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 24
+			},
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 25
+			},
+			{
+				"type": "obj",
+				"mode": "rw",
+				"property": {
+					"min": 0,
+					"max": 86400,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 26
+			},
+			{
+				"type": "obj",
+				"mode": "wr",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 28
+			},
+			{
+				"mode": "rw",
+				"id": 32,
+				"type": "raw"
+			},
+			{
+				"mode": "rw",
+				"id": 33,
+				"type": "raw"
+			}
+		]
+	},
+	"device_configuration": {
+		"Jsonver": "1.1.9",
+		"brightmax": 100,
+		"brightmin": 5,
+		"cagt": 27,
+		"category": "0504",
+		"cmod": "rgbc",
+		"colormax": 100,
+		"colormaxp": 100,
+		"colormin": 10,
+		"colorpfun": 1,
+		"crc": 115,
+		"cwmaxp": 100,
+		"cwtype": 0,
+		"dccur": 13,
+		"defbright": 100,
+		"defcolor": "c",
+		"deftemp": 100,
+		"dmod": 6,
+		"drgbcur": 14,
+		"gmkb": 60,
+		"gmkg": 60,
+		"gmkr": 80,
+		"gmwb": 75,
+		"gmwg": 70,
+		"gmwr": 100,
+		"iicb": 0,
+		"iicc": 4,
+		"iicg": 2,
+		"iicr": 1,
+		"iicscl": 26,
+		"iicsda": 24,
+		"module": "CBLC5",
+		"notdisturb": 0,
+		"onoffmode": 1,
+		"pairt": 600,
+		"pmemory": 1,
+		"prodagain": 0,
+		"remdmode": 1,
+		"rgbt": 8,
+		"rstbr": 50,
+		"rstcor": "c",
+		"rstnum": 3,
+		"rsttemp": 100,
+		"title20": 1,
+		"wfcfg": "spcl_auto",
+		"wfct": 10,
+		"wt": 0
+	}
+}


### PR DESCRIPTION
Thank you very much for working on this project. 

I was able to flash ESPHome on my device without needing any soldering thanks to this profile.

I've just changed the manufacturer and name in the profile file as I flashed another device with this profile.

The original name and manufacturer of this profile is:
```

"manufacturer": "Lepro RGBWWGU10",
"name": "EAN902002EU4 Ceiling Light",
```

Since my experiment was successful, I wanted to give back somehow. Thus, this PR.

Link to this product: https://www.linovum.de/innenbeleuchtung/led-leuchtmittel/led-modul-smart-home-lampe-rgb-cct-dimmbar-4w-230v_4112_3505


The profile.json is not needed?

Cheers,
broaxt
