### PR TITLE
Add Feit Electric LEDR6/RGBW/AG 6in Downlight (BK7231T + BK7231N)

### DIFF
--- a/devices/feit-electric-ledr6-rgbw-ag-6in-rgbct-downlight-bk7231t-v1.0.3.json
+++ b/devices/feit-electric-ledr6-rgbw-ag-6in-rgbct-downlight-bk7231t-v1.0.3.json
@@ -1,0 +1,165 @@
+{
+	"manufacturer": "Feit Electric",
+	"name": "LEDR6/RGBW/AG 6in RGBCT Downlight (WB3L/BK7231T) v1.0.3",
+	"key": "keydpkw438xwpdtm",
+	"ap_ssid": "SmartLife",
+	"github_issues": [],
+	"image_urls": [],
+	"profiles": [
+		"oem-bk7231s-light-ty-olddp-1.0.3-sdk-2.0.0-30.05"
+	],
+	"schemas": {
+		"000001dk4r": [
+			{
+				"mode": "rw",
+				"property": {
+					"type": "bool"
+				},
+				"id": 1,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"range": [
+						"white",
+						"colour",
+						"scene",
+						"scene_1",
+						"scene_2",
+						"scene_3",
+						"scene_4"
+					],
+					"type": "enum"
+				},
+				"id": 2,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"min": 25,
+					"max": 255,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 3,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"min": 0,
+					"max": 255,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 4,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 5,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 6,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 7,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 8,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 9,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 10,
+				"type": "obj"
+			}
+		]
+	},
+	"device_configuration": {
+		"Jsonver": "1.1.6",
+		"b_lv": 1,
+		"b_pin": 26,
+		"brightmax": 100,
+		"brightmin": 10,
+		"c_lv": 1,
+		"c_pin": 7,
+		"cagt": 20,
+		"category": "0505",
+		"cmod": "rgbcw",
+		"colormax": 100,
+		"colormin": 10,
+		"crc": 87,
+		"cwmaxp": 100,
+		"cwtype": 1,
+		"defbright": 100,
+		"defcolor": "c",
+		"deftemp": 0,
+		"dmod": 0,
+		"g_lv": 1,
+		"g_pin": 24,
+		"gmkb": 60,
+		"gmkg": 60,
+		"gmkr": 80,
+		"gmwb": 75,
+		"gmwg": 70,
+		"gmwr": 100,
+		"module": "WB3L",
+		"onoffmode": 0,
+		"pmemory": 1,
+		"prodagain": 0,
+		"pwmhz": 3000,
+		"r_lv": 1,
+		"r_pin": 8,
+		"rgbt": 10,
+		"rstbr": 50,
+		"rstcor": "c",
+		"rstnum": 3,
+		"rsttemp": 0,
+		"title20": 1,
+		"w_lv": 1,
+		"w_pin": 6,
+		"wfcfg": "spcl_auto",
+		"wfct": 3,
+		"wt": 20
+	}
+}

--- a/devices/feit-electric-ledr6-rgbw-ag-6in-rgbct-downlight-cbu-v1.0.3.json
+++ b/devices/feit-electric-ledr6-rgbw-ag-6in-rgbct-downlight-cbu-v1.0.3.json
@@ -1,0 +1,185 @@
+{
+	"manufacturer": "Feit Electric",
+	"name": "LEDR6/RGBW/AG 6in RGBCT Downlight (CBU/BK7231N) v1.0.3",
+	"key": "keymvpc73guk4ycy",
+	"ap_ssid": "SmartLife",
+	"github_issues": [],
+	"image_urls": [],
+	"profiles": [
+		"oem-bk7231n-light5-hailai-1.0.3-sdk-2.3.1-40.00"
+	],
+	"schemas": {
+		"000003h8gm": [
+			{
+				"mode": "rw",
+				"property": {
+					"type": "bool"
+				},
+				"id": 20,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"range": [
+						"white",
+						"colour",
+						"scene",
+						"music"
+					],
+					"type": "enum"
+				},
+				"id": 21,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"min": 10,
+					"max": 1000,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 22,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"min": 0,
+					"max": 1000,
+					"scale": 0,
+					"step": 1,
+					"type": "value"
+				},
+				"id": 23,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 24,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 25,
+				"type": "obj"
+			},
+			{
+				"mode": "wr",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 27,
+				"type": "obj"
+			},
+			{
+				"mode": "wr",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 28,
+				"type": "obj"
+			},
+			{
+				"mode": "wr",
+				"property": {
+					"type": "string",
+					"maxlen": 255
+				},
+				"id": 29,
+				"type": "obj"
+			},
+			{
+				"mode": "rw",
+				"id": 30,
+				"type": "raw"
+			},
+			{
+				"mode": "rw",
+				"id": 31,
+				"type": "raw"
+			},
+			{
+				"mode": "rw",
+				"id": 32,
+				"type": "raw"
+			},
+			{
+				"mode": "rw",
+				"id": 33,
+				"type": "raw"
+			},
+			{
+				"mode": "rw",
+				"id": 210,
+				"type": "raw"
+			}
+		]
+	},
+	"device_configuration": {
+		"Jsonver": "1.0.0",
+		"b_lv": 1,
+		"b_pin": 6,
+		"brightmax": 100,
+		"brightmin": 10,
+		"c_lv": 1,
+		"c_pin": 8,
+		"cagt": 20,
+		"category": "0505",
+		"cmod": "rgbcw",
+		"colormax": 100,
+		"colormin": 10,
+		"colorpfun": 0,
+		"crc": 32,
+		"cwmaxp": 100,
+		"cwtype": 1,
+		"defbright": 100,
+		"defcolor": "c",
+		"deftemp": 0,
+		"dmod": 0,
+		"g_lv": 1,
+		"g_pin": 24,
+		"gmkb": 60,
+		"gmkg": 60,
+		"gmkr": 80,
+		"gmwb": 75,
+		"gmwg": 70,
+		"gmwr": 100,
+		"irfunc": 0,
+		"module": "CBU",
+		"mutex": 1,
+		"nightled": 0,
+		"notdisturb": 0,
+		"onoffmode": 0,
+		"onofftime": 800,
+		"pmemory": 1,
+		"prodagain": 0,
+		"pwmhz": 3000,
+		"r_lv": 1,
+		"r_pin": 26,
+		"remdmode": 0,
+		"rgbt": 10,
+		"rstbr": 50,
+		"rstcor": "c",
+		"rstnum": 3,
+		"rsttemp": 0,
+		"title20": 0,
+		"w_lv": 1,
+		"w_pin": 7,
+		"wfcfg": "spcl_auto",
+		"wfct": 3,
+		"wt": 20
+	}
+}

--- a/profiles/oem-bk7231n-light5-hailai-1.0.3-sdk-2.3.1-40.00.json
+++ b/profiles/oem-bk7231n-light5-hailai-1.0.3-sdk-2.3.1-40.00.json
@@ -1,0 +1,18 @@
+{
+	"name": "1.0.3 - BK7231N",
+	"sub_name": "oem_bk7231n_light5_hailai",
+	"type": "CLASSIC",
+	"icon": "lightbulb-outline",
+	"firmware": {
+		"chip": "BK7231N",
+		"name": "oem_bk7231n_light5_hailai",
+		"version": "1.0.3",
+		"sdk": "2.3.1-40.00",
+		"key": "keymvpc73guk4ycy"
+	},
+	"data": {
+		"address_finish": "0x1B5AB",
+		"address_ssid": "0xD6005",
+		"address_ssid_padding": 4
+	}
+}


### PR DESCRIPTION
## Summary

Adds two verified device profiles for the **Feit Electric LEDR6/RGBW/AG** 6-inch RGBCT recessed downlight. This model ships with two different Tuya modules depending on manufacturing batch:

### BK7231T variant (WB3L module)
- **Firmware:** `oem_bk7231s_light_ty_oldDp` v1.0.3, SDK 2.0.0, base 30.05
- **References existing profile** `oem-bk7231s-light-ty-olddp-1.0.3-sdk-2.0.0-30.05` (already in repo)
- 5-channel RGBCW, old datapoint schema (DPs 1-10)

### BK7231N variant (CBU module)
- **Firmware:** `oem_bk7231n_light5_hailai` v1.0.3, SDK 2.3.1, base 40.00
- **New profile** `oem-bk7231n-light5-hailai-1.0.3-sdk-2.3.1-40.00` with unique addresses
- 5-channel RGBCW, new datapoint schema (DPs 20+)
- Note: v1.0.0 and v1.0.2 profiles exist but have different addresses

### Files added
- `devices/feit-electric-ledr6-rgbw-ag-6in-rgbct-downlight-bk7231t-v1.0.3.json`
- `devices/feit-electric-ledr6-rgbw-ag-6in-rgbct-downlight-cbu-v1.0.3.json`
- `profiles/oem-bk7231n-light5-hailai-1.0.3-sdk-2.3.1-40.00.json`

### Verification
Both profiles were built from full 2MB serial flash dumps using `build_profile.py` and tested end-to-end via cloudcutter OTA to ESPHome Kickstart firmware. Both units are running ESPHome successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)